### PR TITLE
hd-qteglfs-platform: add COMPATIBLE_MACHINE

### DIFF
--- a/recipes-graphics/hd-libgles/hd-qteglfs-platform.bb
+++ b/recipes-graphics/hd-libgles/hd-qteglfs-platform.bb
@@ -4,6 +4,8 @@ PRIORITY = "required"
 LICENSE = "CLOSED"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+COMPATIBLE_MACHINE = "hd51|vs1500|bre2ze4k"
+
 PR = "r1"
 
 QEGLFS = "qt5/plugins/egldeviceintegrations"


### PR DESCRIPTION
Fixes the following warning:
WARNING: /.../hd-qteglfs-platform.bb: Unable to get checksum for hd-qteglfs-platform SRC_URI entry libqeglfs-nxpl-integration.so: file could not be found