### PR TITLE
provide install package for firmware-rtl8192eu

### DIFF
--- a/conf/machine/include/hd-essential.inc
+++ b/conf/machine/include/hd-essential.inc
@@ -14,6 +14,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS = "\
 	firmware-rtl8712u \
 	firmware-rtl8188eu \
 	firmware-rtl8192cu \
+	firmware-rtl8192eu \
 	firmware-rtl8xxxu \
 	firmware-zd1211 \
 	\


### PR DESCRIPTION
"rc" and "develop" branches of the main repo already provide firmware-rtl8192eu . The rtl8xxxu module already supports it. Only the actual firmware dependency is missing to make it available.