### PR TITLE
build qt packages for machine arch

### DIFF
--- a/conf/machine/include/hd.inc
+++ b/conf/machine/include/hd.inc
@@ -22,6 +22,7 @@ DVBMEDIASINK_CONFIG_mipsel = "--with-wma --with-wmv --with-pcm --with-dts --with
 	${@bb.utils.contains('MACHINE_FEATURES', 'h265', '--with-h265 --with-vb6 --with-vb8 --with-spark' , '', d)} \
 	"
 EXTRA_OECONF_append_pn-kodi = " --with-gpu=v3d"
+QT_PACKAGES_ARCH = "${MACHINE_ARCH}"
 PACKAGECONFIG_GL_pn-qtbase = "gles2 linuxfb"
 
 IMAGEVERSION := "${DISTRO_NAME}-${DISTRO_VERSION}-${DATE}"


### PR DESCRIPTION
Openpli build fails by multiply Qt builds.
Build all Qt packages separate for each machine arch. 