### PR TITLE
enable support for hauppauge dvb wintv solo hd

### DIFF
--- a/recipes-bsp/linux/files/enable_hauppauge_solohd.patch
+++ b/recipes-bsp/linux/files/enable_hauppauge_solohd.patch
@@ -1,0 +1,15 @@
+diff --git a/drivers/media/usb/em28xx/em28xx-cards.c b/drivers/media/usb/em28xx/em28xx-cards.c
+index 23c67494..0111feac 100644
+--- a/drivers/media/usb/em28xx/em28xx-cards.c
++++ b/drivers/media/usb/em28xx/em28xx-cards.c
+@@ -2576,6 +2576,10 @@ struct usb_device_id em28xx_id_table[] = {
+			.driver_info = EM28178_BOARD_PCTV_292E },
+	{ USB_DEVICE(0x2040, 0x0264), /* Hauppauge WinTV-soloHD */
+			.driver_info = EM28178_BOARD_PCTV_292E },
++	{ USB_DEVICE(0x2040, 0x8264), /* Hauppauge OEM Generic WinTV-soloHD Bulk */
++			.driver_info = EM28178_BOARD_PCTV_292E },
++	{ USB_DEVICE(0x2040, 0x8268), /* Hauppauge Retail WinTV-soloHD Bulk */
++			.driver_info = EM28178_BOARD_PCTV_292E },
+	{ USB_DEVICE(0x0413, 0x6f07),
+			.driver_info = EM2861_BOARD_LEADTEK_VC100 },
+	{ USB_DEVICE(0xeb1a, 0x8179),

--- a/recipes-bsp/linux/linux-hd_4.10.12.bb
+++ b/recipes-bsp/linux/linux-hd_4.10.12.bb
@@ -34,6 +34,7 @@ SRC_URI_append_arm = " \
 	file://reserve_dvb_adapter_0.patch \
 	file://blacklist_mmc0.patch \
 	file://export_pmpoweroffprepare.patch \
+	file://enable_hauppauge_solohd.patch \
 "
 
 S = "${WORKDIR}/linux-${PV}"


### PR DESCRIPTION
enable support for hauppauge dvb wintv solo hd
by adding new vid/pid from upstream kernel