### PR TITLE
zeus: python should use 4 spaces indentation

### DIFF
--- a/recipes-bsp/mali/kernel-module-mali-utgard.inc
+++ b/recipes-bsp/mali/kernel-module-mali-utgard.inc
@@ -36,18 +36,18 @@ do_install_append() {
 FILES_${PN} += "${sysconfdir}/modules-load.d/_mali.conf"
 
 python() {
-	platform = d.getVar('MALI_DRIVER_PLATFORM', True)
-	if not platform:
-		platform = "devicetree"
-		TARGET_PLATFORM=" mali450"
+    platform = d.getVar('MALI_DRIVER_PLATFORM', True)
+    if not platform:
+        platform = "devicetree"
+        TARGET_PLATFORM=" mali450"
 
-	config = ["CONFIG_MALI_SHARED_INTERRUPTS=y",
-		"CONFIG_MALI400=m",
-		"CONFIG_MALI450=y",
-		"CONFIG_MALI_DVFS=y",
-		"CONFIG_GPU_AVS_ENABLE=y"]
+    config = ["CONFIG_MALI_SHARED_INTERRUPTS=y",
+        "CONFIG_MALI400=m",
+        "CONFIG_MALI450=y",
+        "CONFIG_MALI_DVFS=y",
+        "CONFIG_GPU_AVS_ENABLE=y"]
 
-	for c in config:
-		d.appendVar('MALI_FLAGS', '-D' + c + ' ')
-		d.appendVar('MALI_KCONFIG', c + ' ')
+    for c in config:
+        d.appendVar('MALI_FLAGS', '-D' + c + ' ')
+        d.appendVar('MALI_KCONFIG', c + ' ')
 }


### PR DESCRIPTION
This commit fixes the following warnings from bitbake:
WARNING: /zeus/meta-gfutures/recipes-bsp/mali/kernel-module-mali-hd60_r7p0-00rel0.bb: python should use 4 spaces indentation, but found tabs in kernel-module-mali-utgard.inc, line 39
...
WARNING: /zeus/meta-gfutures/recipes-bsp/mali/kernel-module-mali-hd61_r7p0-00rel0.bb: python should use 4 spaces indentation, but found tabs in kernel-module-mali-utgard.inc, line 52