### PR TITLE
meta-gfutures: rename v3d-nxpl to v3d-cortexa15 and v3dmipsel

### DIFF
--- a/conf/machine/bre2ze4k.conf
+++ b/conf/machine/bre2ze4k.conf
@@ -2,7 +2,7 @@
 #@NAME: wwio bre2ze4k
 #@DESCRIPTION: Machine configuration for the bre2ze4k
 
-MACHINE_FEATURES += "dvb-c textlcd qteglfs v3d-nxpl swap emmc"
+MACHINE_FEATURES += "dvb-c textlcd qteglfs v3d-cortexa15 swap emmc"
 OPENPLI_FEATURES += "ci qthbbtv kodi"
 DISTRO_FEATURES_remove = "x11 wayland directfb"
 

--- a/conf/machine/hd2400.conf
+++ b/conf/machine/hd2400.conf
@@ -2,7 +2,7 @@
 #@NAME: hd2400
 #@DESCRIPTION: Machine configuration for the hd2400
 
-MACHINE_FEATURES += "dvb-c transcoding v3d-nxpl"
+MACHINE_FEATURES += "dvb-c transcoding v3d-mipsel"
 OPENPLI_FEATURES += "ci kodi"
 DISTRO_FEATURES_remove = "x11 wayland directfb"
 

--- a/conf/machine/hd51.conf
+++ b/conf/machine/hd51.conf
@@ -2,7 +2,7 @@
 #@NAME: hd51
 #@DESCRIPTION: Machine configuration for the hd51
 
-MACHINE_FEATURES += "dvb-c textlcd qteglfs v3d-nxpl swap emmc"
+MACHINE_FEATURES += "dvb-c textlcd qteglfs v3d-cortexa15 swap emmc"
 OPENPLI_FEATURES += "ci qtplugins kodi"
 DISTRO_FEATURES_remove = "x11 wayland directfb"
 

--- a/conf/machine/include/hd-essential.inc
+++ b/conf/machine/include/hd-essential.inc
@@ -6,7 +6,8 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = " \
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS = "\
 	kernel-module-cdfs \
-	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-nxpl', 'hd-v3ddriver-${MACHINE}' , '', d)} \
+	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-mipsel', 'hd-v3ddriver-${MACHINE}' , '', d)} \
+	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-cortexa15', 'hd-v3ddriver-${MACHINE}' , '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'qtegls', 'hd-qteglfs-platform', '',d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'mali', 'hd-mali-${MACHINE} kernel-module-mali-${MACHINE}' , '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'emmc', 'resizerootfs partitions-by-name' , '', d)} \

--- a/conf/machine/include/hd.inc
+++ b/conf/machine/include/hd.inc
@@ -27,8 +27,6 @@ DVBMEDIASINK_CONFIG_arm = "--with-h265 --with-vb8 --with-vb9 --with-wma --with-w
 DVBMEDIASINK_CONFIG_mipsel = "--with-wma --with-wmv --with-pcm --with-dts --with-eac3 \
 	${@bb.utils.contains('MACHINE_FEATURES', 'h265', '--with-h265 --with-vb6 --with-vb8 --with-spark' , '', d)} \
 	"
-EXTRA_OECONF_append_pn-kodi = " --with-gpu=v3d"
-EXTRA_OECMAKE_append_pn-kodi += " -DWITH_V3D=nxpl"
 
 PACKAGECONFIG_GL_pn-qtbase = " "
 PACKAGECONFIG_append_pn-qtbase += " gles2 linuxfb"

--- a/conf/machine/vs1500.conf
+++ b/conf/machine/vs1500.conf
@@ -2,7 +2,7 @@
 #@NAME: vs1500
 #@DESCRIPTION: Machine configuration for the vs1500
 
-MACHINE_FEATURES += "dvb-c textlcd qteglfs v3d-nxpl swap emmc"
+MACHINE_FEATURES += "dvb-c textlcd qteglfs v3d-cortexa15 swap emmc"
 OPENPLI_FEATURES += "ci qtplugins kodi"
 DISTRO_FEATURES_remove = "x11 wayland directfb"
 


### PR DESCRIPTION
for the supported devices

bre2ze4k, hd2400, hd51, vs1500

 -this split is following the naming used by OE-A and OpenPLi
 -remove the EXTRA_OECONF / EXTRA_OECMAKE not necessary here

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>