### PR TITLE
hd-hi3798mv: remove EXTRA_OECONF for kodi

### DIFF
--- a/conf/machine/include/hd-hi3798mv.inc
+++ b/conf/machine/include/hd-hi3798mv.inc
@@ -30,9 +30,6 @@ EXTRA_OECONF_append_pn-enigma2 += " --with-alphablendingacceleration=always --wi
 PACKAGECONFIG_GL_pn-qtbase = " "
 PACKAGECONFIG_append_pn-qtbase += " gles2 linuxfb"
 
-# Kodi
-EXTRA_OECONF_append_pn-kodi += " --with-gpu=mali --enable-player=hiplayer"
-
 # Gstreamer dvbmediasink
 DVBMEDIASINK_CONFIG = "--with-h265 --with-vb8 --with-vb9 --with-wma --with-wmv --with-pcm --with-eac3 --with-amr --with-spark"
 


### PR DESCRIPTION
- first, kodi_18 uses EXTRA_OECMAKE
- then, this value is defined in the recipe using MACHINE_FEATURES

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>